### PR TITLE
Fix formatting prices

### DIFF
--- a/src/components/shelf/Product.js
+++ b/src/components/shelf/Product.js
@@ -12,7 +12,7 @@ const Product = (props) => {
   // Um componente de input pode alterar a quantidade no futuro
   product.quantity = 1;
 
-  let formattedPrice = util.formatPrice(product.price, product.currencyId);
+  let formattedPrice = util.formatPrice(product.price, product.currencyId).toFixed(2);
   
   let productInstallment;
   
@@ -21,7 +21,7 @@ const Product = (props) => {
 
     productInstallment = (
       <div className="installment">
-        <span>ou {product.installments} x</span><b> {product.currencyFormat} {util.formatPrice(installmentPrice, product.currencyId)}</b>
+        <span>ou {product.installments} x</span><b> {product.currencyFormat} {util.formatPrice(installmentPrice, product.currencyId).toFixed(2)}</b>
       </div>
     );
   }
@@ -40,11 +40,8 @@ const Product = (props) => {
       <div className="shelf-item__price">
         <div className="val"><small>{product.currencyFormat}</small>
           <b>
-            {formattedPrice.substr(0, formattedPrice.length - 3)}
+            {formattedPrice}
           </b>
-          <span>
-            {formattedPrice.substr(formattedPrice.length - 3, 3)}
-          </span>
         </div>
         {productInstallment}
       </div>


### PR DESCRIPTION
Starting the project, I was getting this error: 

```
TypeError: formattedPrice.substr is not a function
Product
src/components/shelf/Product.js:43
  40 | <div className="shelf-item__price">
  41 |   <div className="val"><small>{product.currencyFormat}</small>
  42 |     <b>
> 43 |       {formattedPrice.substr(0, formattedPrice.length - 3)}
  44 |     </b>
  45 |     <span>
  46 |       {formattedPrice.substr(formattedPrice.length - 3, 3)}
```
seeing that `formattedPrice` isn't a string here. 

I've fixed that with a simple solution. It should avoid the app to break.